### PR TITLE
feature/51021_Add_gem_paranoia

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ gem "omniauth-rails_csrf_protection", "~> 1.0"
 
 gem "cancancan"
 gem "ransack"
+
+gem "paranoia", "~> 2.2"
 # Use Active Storage variant
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,8 @@ GEM
     pagy (5.10.1)
       activesupport
     parallel (1.22.1)
+    paranoia (2.6.0)
+      activerecord (>= 5.1, < 7.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
     pry (0.14.1)
@@ -403,6 +405,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   omniauth-rails_csrf_protection (~> 1.0)
   pagy
+  paranoia (~> 2.2)
   pry (~> 0.14.0)
   puma (~> 4.1)
   rails (~> 6.0.5)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,6 @@
 class Admin::UsersController < Admin::AdminController
+  before_action :load_user, only: %i(destroy restore really_destroy)
+
   def index
     @search = User.order_by_name.ransack(params[:search])
     @pagy, @users = pagy @search.result, items: Settings.default_page
@@ -6,5 +8,51 @@ class Admin::UsersController < Admin::AdminController
       format.html
       format.js
     end
+  end
+
+  def restores
+    @search = User.only_deleted.order_by_name.ransack(params[:search])
+    @pagy, @users = pagy @search.result, items: Settings.default_page
+    respond_to do |format|
+      format.html
+      format.js
+    end
+  end
+
+  def destroy
+    if @user.destroy
+      flash[:success] = t ".destroy_success_message"
+      redirect_to restores_admin_users_path
+    else
+      flash.now[:danger] = t ".destroy_failure_message"
+      render :index
+    end
+  end
+
+  def restore
+    if @user.restore
+      flash[:success] = t ".restore_success_message"
+      redirect_to admin_root_path
+    else
+      flash.now[:danger] = t ".restore_failure_message"
+      render :restores
+    end
+  end
+
+  def really_destroy
+    if @user.really_destroy!
+      flash[:success] = t ".really_destroy_success"
+    else
+      flash[:danger] = t ".really_destroy_message"
+    end
+    redirect_to admin_root_path
+  end
+
+  def load_user
+    @user = User.with_deleted.find_by id: params[:id]
+    return if @user
+
+    flash[:danger] = t "not_found_user"
+    redirect_to admin_root_path
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  acts_as_paranoid
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable,
          :omniauthable, omniauth_providers: [:google_oauth2]

--- a/app/views/admin/users/_search.html.erb
+++ b/app/views/admin/users/_search.html.erb
@@ -1,8 +1,8 @@
 <div class="align-center ">
-  <%= search_form_for [:admin, @search], class:"navbar-form flex flex-space-between ", remote: true do |f| %>
+  <%= search_form_for @search, url: url, class:"navbar-form flex flex-space-between ", remote: true do |f| %>
     <div class="flex align-end">
       <i class="fa-solid fa-filter s-16 m-r-5"></i>
-      <%= sort_link @search, :created_at, t(".created_at") %>
+      <%= sort_link @search, :confirmed_at, t(".confirmed_at") %>
     </div>
     <div class="input-group flex align-end">
       <div class="flex">

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -25,6 +25,23 @@
     <td>
       <h5 class="m-b-0"><%= l(user.created_at) %></h5>
     </td>
+    <% if user.user? %>
+      <% if user.deleted? %>
+        <td>
+          <%= link_to t(".restore"), restore_admin_user_path(user), method: :patch,
+           data: { confirm: t(".sure_restore") }, class: "btn btn-success btn-md" %>
+        </td>
+      <% else %>
+        <td>
+          <%= link_to t(".destroy"), admin_user_path(user), method: :delete, remote: true,
+           data: { confirm: t(".sure_delete") }, class: "btn btn-warning" %>
+        </td>
+       <% end %>
+      <td>
+        <%= link_to t(".really_destroy"), really_destroy_admin_user_path(user), method: :delete,
+         data: { confirm: t(".sure_really_destroy") }, class: "btn btn btn-danger" %>
+      </td>
+    <% end %>
   </tr>
 </tbody>
 <%= render "shared/show_user" , object: user %>

--- a/app/views/admin/users/restores.html.erb
+++ b/app/views/admin/users/restores.html.erb
@@ -1,10 +1,10 @@
 <% provide :title, t(".title") %>
 <h1><%= t ".welcome" %></h1>
-<%= link_to restores_admin_users_path, class: "btn btn-lg active" do %>
-  <i class="fa-solid fa-chevron-right"></i>
-  <%= t ".restores" %>
+<%= link_to admin_users_path, class: "btn btn-lg active" do %>
+  <i class="fa-solid fa-angles-left"></i>
+  <%= t ".admin_user" %>
 <% end %>
-<div><%= render "search", url: admin_users_path %></div>
+<div><%= render "search", url: restores_admin_users_path %></div>
 <div class="page-breadcrumb">
   <div class="row">
     <div class="col-6">

--- a/app/views/admin/users/restores.js.erb
+++ b/app/views/admin/users/restores.js.erb
@@ -1,0 +1,3 @@
+$("#table-user").html("<%= j render "users" %>");
+$("#count-user").html("<%= j render "count" %>");
+$(".table-responsive > .align-center").hide();

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -183,10 +183,22 @@ en:
   label_transaction: transaction
   admin:
     users:
+      index:
+        welcome: All Users
+        restores: Restores
+        user: Users
+      destroy:
+        destroy_success_message: Destroy success
+        destroy_failure_message: Destroy failed
+      restore:
+        restore_success_message: Restore success
+        restore_failure_message: Restore failed
+      really_destroy:
+        really_destroy_success: Really destroy success
+        really_destroy_message: Really destroy failed
       users:
         index:
           title: Users
-          welcome: All Users
           name: Name user
           email: Email
           role: Role
@@ -197,9 +209,20 @@ en:
           user: Total user
           unauthorization: "You don't have permission to do this action"
       search:
-        created_at: Create at
+        confirmed_at: Confirmed at
         search_name_and_email: Search name or email
         search_created_date: Search created time
+      user:
+        sure_restore: You sure restore?
+        destroy: Destroy
+        restore: Restore
+        sure_delete: "You sure delete?" 
+        really_destroy: Really destroy
+        sure_really_destroy: "You sure really destroy?"
+      restores: 
+        welcome: Restore users
+        admin_user: Admin Users
+        user: Users
   show: Show
   success_wallet: "Create wallet success"
   danger_wallet: "Create wallet fail"
@@ -215,3 +238,4 @@ en:
   danger_delete: "Do you really want to delete these account? This process cannot be undone."
   cancel_account: "Cancel my account"
   cancel: Cancel
+  not_found_user: User not found

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -195,6 +195,19 @@ ja:
   label_transaction: トランザクション
   admin:
     users:
+      index:
+        welcome: 全てのユーザー
+        restores: 復元
+        user: ユーザー
+      destroy:
+        destroy_success_message: 成功を破壊する
+        destroy_failure_message: 破壊に失敗しました
+      restore:
+        restore_success_message: 成功を回復する
+        restore_failure_message: 復元に失敗しました
+      really_destroy:
+        really_destroy_success: 本当に成功を破壊する
+        really_destroy_message: 本当に成功に失敗しました
       users:
         title: ユーザー
         welcome: 全てのユーザー
@@ -209,9 +222,20 @@ ja:
         create_at: "作成"
         unauthorization: "このアクションを実行する権限がありません"
       search:
-        created_at: 作成
+        confirmed_at: 作成
         search_name_and_email: 名前またはメールアドレスを検索
         search_created_date: 作成時間を検索
+      user:
+        sure_restore: 確かに復元しますか？
+        destroy: 破壊
+        restore: 戻す
+        sure_delete: "削除しますか？" 
+        really_destroy: 本当に破壊する
+        sure_really_destroy: "あなたは確かに本当に破壊します?"
+      restores: 
+        welcome: ユーザーを復元する
+        admin_user: 管理者ユーザー
+        user: ユーザー
   show: 見せる
   authorzie_warning: "このアクションを実行する権限がありません"
   current_password: 現在のパスワード

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -198,9 +198,21 @@ vi:
   label_transaction: giao dịch
   admin:
     users:
+      index:
+        welcome: Tất cả người sử dụng
+        restores: Khôi phục
+        user: Người dùng
+      destroy:
+        destroy_success_message: Xóa tạm thời thành công
+        destroy_failure_message: Xóa tạm thời thất bại
+      restore:
+        restore_success_message: Khôi phục thành công
+        restore_failure_message: Khôi phục thất bại
+      really_destroy:
+        really_destroy_success: Xóa thành công
+        really_destroy_message: Xóa thất bại
       users:
         title: Người dùng
-        welcome: Tất cả người sử dụng
         name: Tên người dùng
         email: Email
         role: Role
@@ -211,9 +223,20 @@ vi:
         user: Tổng số người dùng
         create_at: "Ngày tạo"
       search:
-        created_at: Ngày tạo
+        confirmed_at: Ngày xác nhận
         search_name_and_email: Tìm theo tên hoặc email
         search_created_date: Tìm theo ngày
+      user:
+        sure_restore: Chắc muốn khôi phục người dùng?
+        destroy: Xóa tạm thời
+        restore: Khôi phục
+        sure_delete: "Bạn chắc muốn xóa người dùng?" 
+        really_destroy: Xóa người dùng
+        sure_really_destroy: "Bạn muốn xóa người dùng, không thể khôi phục được?"
+      restores: 
+        welcome: Khôi phục người dùng
+        admin_user: Tất cả người đang hoạt động
+        user: Người dùng
   show: Cho xem
   authorzie_warning: "Bạn không thể truy cập"
   current_password: Mật khẩu hiện tại

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,13 @@ Rails.application.routes.draw do
     resources :transactions, only: %i(create destroy update)
     namespace :admin do
       root "users#index"
-      resources :users
+      resources :users do
+        member do
+          patch "restore"
+          delete "really_destroy"
+        end
+        get "restores", on: :collection
+      end
     end
   end
 end

--- a/db/migrate/20220713082330_add_deleted_at_to_users.rb
+++ b/db/migrate/20220713082330_add_deleted_at_to_users.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :deleted_at, :datetime
+    add_index :users, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_12_031734) do
+ActiveRecord::Schema.define(version: 2022_07_13_082330) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
@@ -50,7 +50,9 @@ ActiveRecord::Schema.define(version: 2022_07_12_031734) do
     t.string "unconfirmed_email"
     t.string "provider"
     t.string "uid"
+    t.datetime "deleted_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,8 +2,14 @@ User.create!(name: "Minh Luong",
     email: "duongminhluong89@gmail.com",
     password: "123456",
     password_confirmation: "123456",
-    role: 0,
+    role: 1,
     confirmed_at: Time.zone.now)
+10.times do |n|
+  name = Faker::Name.name
+  email = Faker::Internet.email
+  password = "123456"
+  User.create!(name: name, email: email, password: password, password_confirmation: password, confirmed_at: Time.zone.now)
+end
 
 categories = [["Eat rice", 1], ["My salary", 0], ["Car fare", 1]]
 categories.each do |key, value|

--- a/spec/controllers/admin/user_controller_spec.rb
+++ b/spec/controllers/admin/user_controller_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 require "cancan/matchers"
 RSpec.describe Admin::UsersController, type: :controller do
   let!(:user) {FactoryBot.create :user, name: "User 1"}
+  let!(:user_1) {FactoryBot.create :user, name: "User 3", deleted_at: Time.zone.now}
   let!(:user_admin) {FactoryBot.create :user, role: 1, name: "User 2"}
 
   describe "#GET index" do
@@ -49,6 +50,188 @@ RSpec.describe Admin::UsersController, type: :controller do
           it "should find just categories" do
             expect(assigns(:users)).to eq [user]
           end
+        end
+      end
+    end
+  end
+
+  describe "#GET restores" do
+    context "when admin login" do
+      before do
+        sign_in user_admin
+        get :restores
+      end
+      it "returns a 200 response" do
+        expect(response).to have_http_status "200"
+      end
+      it {expect(assigns(:pagy).count).to eq 1}
+
+      context "search sort users" do
+        it "gets user by name or email" do
+          expect(User.only_deleted.ransack(user_cont: user_1.name).result.pluck(:id)).to eq [user_1.id]
+        end
+
+        it "gets user by created_at" do
+          expect(User.only_deleted.ransack(created_at_eq: user_1.created_at).result.pluck(:id)).to eq [user_1.id]
+        end
+
+        context "when search params" do
+          before do
+            get :restores, params: {
+              search: {user_cont: "User 3", created_at_eq: Time.zone.now} }
+          end
+          it "should find just categories" do
+            expect(assigns(:users)).to eq [user_1]
+          end
+        end
+      end
+    end
+  end
+
+  describe "DELETE destroy" do
+    context "when user logged" do
+      before do
+        sign_in user_admin
+      end
+      context "when delete success" do
+        before do
+          patch :destroy, params: { id: user.id}
+        end
+        it {expect(flash[:success]).to eq "Destroy success"}
+        
+        it {expect(User.only_deleted.pluck(:id)).to eq [user.id, user_1.id]}
+
+        it {expect(User.pluck(:id)).to eq [user_admin.id]}
+
+        it "redirect to transaction" do
+          expect(response).to redirect_to restores_admin_users_path
+        end
+      end
+      context "When delete failed" do
+        before do
+          allow_any_instance_of(User).to receive(:destroy).and_return false
+          patch :destroy, params: { id: user_1.id}
+        end
+        it "delete failed" do
+          expect(flash[:danger]).to eq "Destroy failed"
+        end
+
+        it {expect(User.pluck(:id)).to eq [user.id, user_admin.id]}
+
+        it {expect(User.only_deleted.pluck(:id)).to eq [user_1.id]}
+
+        it "render index" do
+          expect(response).to render_template :index
+        end
+      end
+
+      context "when find not found" do
+        before do
+          patch :destroy, params: { id: -12}
+        end
+        it "show flash danger" do
+          expect(flash[:danger]).to eq "User not found"
+        end
+        it "redirect to categories" do
+          expect(response).to redirect_to admin_root_path
+        end
+      end
+    end
+  end
+
+  describe "UPDATE restore" do
+    context "when user logged" do
+      before do
+        sign_in user_admin
+      end
+      context "when restore success" do
+        before do
+          patch :restore, params: { id: user_1.id}
+        end
+        it {expect(flash[:success]).to eq "Restore success"}
+
+        it {expect(User.only_deleted.pluck(:id)).to eq []}
+
+        it {expect(User.pluck(:id)).to eq [user.id, user_1.id, user_admin.id]}
+
+        it "redirect to transaction" do
+          expect(response).to redirect_to admin_root_path
+        end
+      end
+      context "When restorefailed" do
+        before do
+          allow_any_instance_of(User).to receive(:restore).and_return false
+          patch :restore, params: { id: user_1.id}
+        end
+        it "restore failed" do
+          expect(flash[:danger]).to eq "Restore failed"
+        end
+
+        it {expect(User.only_deleted.pluck(:id)).to eq [user_1.id]}
+
+        it {expect(User.pluck(:id)).to eq [user.id, user_admin.id]}
+      
+        it "render :restores" do
+          expect(response).to render_template :restores
+        end
+      end
+
+      context "when find not found" do
+        before do
+          patch :restore, params: { id: -12}
+        end
+        it "show flash danger" do
+          expect(flash[:danger]).to eq "User not found"
+        end
+        it "redirect to categories" do
+          expect(response).to redirect_to admin_root_path
+        end
+      end
+    end
+  end
+
+  describe "DELETE really_destroy" do
+    context "when user logged" do
+      before do
+        sign_in user_admin
+      end
+      context "when really destroy success" do
+        before do
+          delete :really_destroy, params: { id: user.id}
+        end
+        it {expect(flash[:success]).to eq "Really destroy success"}
+        
+        it {expect(User.with_deleted.pluck(:id)).to eq [user_admin.id, user_1.id]}
+
+        it "redirect to admin root path" do
+          expect(response).to redirect_to admin_root_path
+        end
+      end
+      context "When really destroy failed" do
+        before do
+          allow_any_instance_of(User).to receive(:really_destroy!).and_return false
+          delete :really_destroy, params: { id: user_1.id}
+        end
+        it "really destroy failed" do
+          expect(flash[:danger]).to eq "Really destroy failed"
+        end
+
+        it {expect(User.with_deleted.pluck(:id)).to eq [user.id, user_admin.id, user_1.id]}
+
+        it "redirect to admin root path" do
+          expect(response).to redirect_to admin_root_path
+        end
+      end
+
+      context "when find not found" do
+        before do
+          delete :really_destroy, params: { id: -12}
+        end
+        it "show flash danger" do
+          expect(flash[:danger]).to eq "User not found"
+        end
+        it "redirect to categories" do
+          expect(response).to redirect_to admin_root_path
         end
       end
     end


### PR DESCRIPTION
## Related Tickets
- [#51021](https://edu-redmine.sun-asterisk.vn/issues/51021)

## WHAT (optional)
- gem "paranoia"
- Admin can delete user, restore user and really destroy user

## HOW
- I edit jb file, users_controller.rb.
- I edit rspec users_controller.
-  patch "restore": restore user update deleted_at null
-  delete "really_destroy": delete user db
-  get "restores": get all user with deleted_at not null

## WHY (optional)

## Evidence (Screenshot or Video)
![Screenshot from 2022-07-13 16-31-26](https://user-images.githubusercontent.com/105909649/178703278-dbb29c17-357b-45ef-90b5-473333ea2e05.png)
![Screenshot from 2022-07-13 16-31-18](https://user-images.githubusercontent.com/105909649/178703289-3e13df1e-f284-4929-b80c-b7f49f62d70b.png)
